### PR TITLE
Raise an error if the user try to import ASA 8

### DIFF
--- a/gns3converter/node.py
+++ b/gns3converter/node.py
@@ -22,6 +22,7 @@ from gns3converter.models import MODEL_MATRIX
 from gns3converter.interfaces import INTERFACE_RE, NUMBER_RE, MAPINT_RE, \
     VBQ_INT_RE, Interfaces
 from gns3converter.utils import fix_path
+from gns3converter.converterror import ConvertError
 
 
 class Node(Interfaces):
@@ -213,6 +214,10 @@ class Node(Interfaces):
         global conf section
         """
         device = self.device_info['ext_conf']
+
+        if device == "5520":
+            raise ConvertError("ASA 8 is not supported by GNS3 1.4. You should switch to ASAv. This topology can not be converted.")
+
         node_prop = self.node['properties']
         hv_device = self.hypervisor[device]
         # QEMU HDD Images

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -14,7 +14,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 import unittest
 from gns3converter.node import Node
-
+from gns3converter.converterror import ConvertError
 
 class TestNode(unittest.TestCase):
     def setUp(self):
@@ -391,10 +391,29 @@ class TestNode(unittest.TestCase):
         self.assertListEqual(self.app.node['ports'], exp_res)
         self.assertEqual(self.app.port_id, 3)
 
-    @unittest.skip
     def test_add_to_qemu(self):
-        # TODO
-        self.fail()
+        self.app.node['qemu_id'] = 1
+        self.app.device_info['ext_conf'] = 'QemuDevice'
+        self.app.hypervisor['QemuDevice'] = {}
+        self.app.hypervisor['qemu_path'] = '/bin/qemu'
+
+        self.app.add_to_qemu()
+
+        self.assertEqual(self.app.node['properties']['adapters'], 6)
+        self.assertEqual(self.app.node['properties']['console'], 5001)
+        self.assertEqual(self.app.node['properties']['qemu_path'], '/bin/qemu')
+        self.assertEqual(self.app.node['properties']['ram'], 256)
+
+    def test_add_to_qemu_asa(self):
+        self.app.node['qemu_id'] = 1
+        self.app.device_info['ext_conf'] = '5520'
+        self.app.hypervisor['QemuDevice'] = {}
+        self.app.hypervisor['qemu_path'] = '/bin/qemu'
+
+        try:
+            self.app.add_to_qemu()
+        except ConvertError:
+            self.assertRaises(ConvertError)
 
     def test_add_to_virtualbox(self):
         self.app.node['vbox_id'] = 1


### PR DESCRIPTION
Actually we have too much trouble with recent OS
and ASA 8 with a success rate getting worse each day.
In 1.4.1 we will promote the switch to ASAv sadly it's not
possible to convert from ASA 8 to ASAv.

This PR raise an error making clear to the user that this will
not work.
